### PR TITLE
fix: AR-292 Remove version filter, optimize indexes, fix status and content queries

### DIFF
--- a/src/DotNetCore.CAP.Dashboard/RouteActionProvider.cs
+++ b/src/DotNetCore.CAP.Dashboard/RouteActionProvider.cs
@@ -283,7 +283,7 @@ public class RouteActionProvider
         var pageIndex = httpContext.Request.Query["currentPage"].ToInt32OrDefault(1);
         var name = httpContext.Request.Query["name"].ToString();
         var content = httpContext.Request.Query["content"].ToString();
-        var status = routeValue["status"]?.ToString() ?? nameof(StatusName.Succeeded);
+        var status = NormalizeStatus(routeValue["status"]?.ToString());
 
         var queryDto = new MessageQueryDto
         {
@@ -310,7 +310,7 @@ public class RouteActionProvider
         var name = httpContext.Request.Query["name"].ToString();
         var group = httpContext.Request.Query["group"].ToString();
         var content = httpContext.Request.Query["content"].ToString();
-        var status = routeValue["status"]?.ToString() ?? nameof(StatusName.Succeeded);
+        var status = NormalizeStatus(routeValue["status"]?.ToString());
 
         var queryDto = new MessageQueryDto
         {
@@ -444,6 +444,19 @@ public class RouteActionProvider
             httpContext.Response.StatusCode = (int)HttpStatusCode.BadGateway;
             await httpContext.Response.WriteAsync(e.Message);
         }
+    }
+    
+    private static string NormalizeStatus(string status)
+    {
+        return status?.ToLowerInvariant() switch
+        {
+            "failed"    => nameof(StatusName.Failed),
+            "succeeded" => nameof(StatusName.Succeeded),
+            "scheduled" => nameof(StatusName.Scheduled),
+            "queued"    => nameof(StatusName.Queued),
+            "delayed"   => nameof(StatusName.Delayed),
+            _ => nameof(StatusName.Succeeded)
+        };
     }
 
     private void BadRequest(HttpContext httpContext)

--- a/src/DotNetCore.CAP.MongoDB/IDataStorage.MongoDB.cs
+++ b/src/DotNetCore.CAP.MongoDB/IDataStorage.MongoDB.cs
@@ -265,9 +265,9 @@ public class MongoDBDataStorage : IDataStorage
         var queryResult = await collection
             .Find(x => x.Retries < _capOptions.Value.FailedRetryCount
                        && x.Added < fourMinAgo
-                       && x.Version == _capOptions.Value.Version
                        && (x.StatusName == nameof(StatusName.Failed) ||
                            x.StatusName == nameof(StatusName.Scheduled)))
+            .SortBy(x => x.Added)
             .Limit(200)
             .ToListAsync().ConfigureAwait(false);
         return queryResult.Select(x => new MediumMessage
@@ -286,9 +286,9 @@ public class MongoDBDataStorage : IDataStorage
         var queryResult = await collection
             .Find(x => x.Retries < _capOptions.Value.FailedRetryCount
                        && x.Added < fourMinAgo
-                       && x.Version == _capOptions.Value.Version
                        && (x.StatusName == nameof(StatusName.Failed) ||
                            x.StatusName == nameof(StatusName.Scheduled)))
+            .SortBy(x => x.Added)
             .Limit(200)
             .ToListAsync().ConfigureAwait(false);
         return queryResult.Select(x => new MediumMessage
@@ -321,12 +321,11 @@ public class MongoDBDataStorage : IDataStorage
 
         var update = Builders<PublishedMessage>.Update.Set(x => x._lockToken, ObjectId.GenerateNewId());
 
-        var filter = Builders<PublishedMessage>.Filter.Where(x => x.Version == _capOptions.Value.Version
-                                                                  && ((x.StatusName == nameof(StatusName.Delayed) &&
-                                                                       x.ExpiresAt < DateTime.Now.AddMinutes(2))
-                                                                      ||
-                                                                      (x.StatusName == nameof(StatusName.Queued) &&
-                                                                       x.ExpiresAt < DateTime.Now.AddMinutes(-1)))
+        var filter = Builders<PublishedMessage>.Filter.Where(x => (x.StatusName == nameof(StatusName.Delayed) &&
+                                                                   x.ExpiresAt < DateTime.Now.AddMinutes(2))
+                                                                  ||
+                                                                  (x.StatusName == nameof(StatusName.Queued) &&
+                                                                   x.ExpiresAt < DateTime.Now.AddMinutes(-1))
         );
 
         using var timeoutTs = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -347,6 +346,7 @@ public class MongoDBDataStorage : IDataStorage
                         .ConfigureAwait(false);
 
                     var queryResult = await collection.Find(session, filter)
+                        .SortBy(x => x.Added)
                         .Limit(_capOptions.Value.SchedulerBatchSize)
                         .ToListAsync(linkedTs.Token)
                         .ConfigureAwait(false);

--- a/src/DotNetCore.CAP.MongoDB/IMonitoringApi.MongoDB.cs
+++ b/src/DotNetCore.CAP.MongoDB/IMonitoringApi.MongoDB.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using DotNetCore.CAP.Internal;
 using DotNetCore.CAP.Messages;
@@ -11,6 +12,7 @@ using DotNetCore.CAP.Monitoring;
 using DotNetCore.CAP.Persistence;
 using DotNetCore.CAP.Serialization;
 using Microsoft.Extensions.Options;
+using MongoDB.Bson;
 using MongoDB.Driver;
 
 namespace DotNetCore.CAP.MongoDB;
@@ -127,15 +129,14 @@ public class MongoDBMonitoringApi : IMonitoringApi
         var collection = _database.GetCollection<ReceivedMessage>(_options.ReceivedCollection);
         var builder = Builders<ReceivedMessage>.Filter;
         var filter = builder.Empty;
-        if (!string.IsNullOrEmpty(queryDto.StatusName))
-            filter &= builder.Regex(x => x.StatusName, $"/{queryDto.StatusName}/i");
+        if (!string.IsNullOrEmpty(queryDto.StatusName)) filter &= builder.Eq(x => x.StatusName, queryDto.StatusName);
 
         if (!string.IsNullOrEmpty(queryDto.Name)) filter &= builder.Eq(x => x.Name, queryDto.Name);
 
         if (!string.IsNullOrEmpty(queryDto.Group)) filter &= builder.Eq(x => x.Group, queryDto.Group);
 
         if (!string.IsNullOrEmpty(queryDto.Content))
-            filter &= builder.Regex(x => x.Content, $".*{queryDto.Content}.*");
+            filter &= builder.Regex(x => x.Content, new BsonRegularExpression(Regex.Escape(queryDto.Content), "i"));
 
         var queryItems = await collection.Find(filter)
             .SortByDescending(x => x.Added)

--- a/src/DotNetCore.CAP.MongoDB/IStorageInitializer.MongoDB.cs
+++ b/src/DotNetCore.CAP.MongoDB/IStorageInitializer.MongoDB.cs
@@ -101,11 +101,8 @@ public class MongoDBStorageInitializer : IStorageInitializer
             CreateIndexModel<ReceivedMessage>[] indexes =
             {
                 new(builder.Ascending(x => x.Name)),
-                new(builder.Ascending(x => x.Added)),
-                new(builder.Ascending(x => x.ExpiresAt)),
-                new(builder.Ascending(x => x.Retries)),
-                new(builder.Ascending(x => x.Version)),
-                new(builder.Ascending(x => x.StatusName).Ascending(x => x.ExpiresAt))
+                new(builder.Ascending(x => x.StatusName).Ascending(x => x.ExpiresAt)),
+                new(builder.Ascending(x => x.StatusName).Ascending(x => x.Added))
             };
 
             await col.Indexes.CreateManyAsync(indexes, cancellationToken);
@@ -119,11 +116,8 @@ public class MongoDBStorageInitializer : IStorageInitializer
             CreateIndexModel<PublishedMessage>[] indexes =
             {
                 new(builder.Ascending(x => x.Name)),
-                new(builder.Ascending(x => x.Added)),
-                new(builder.Ascending(x => x.ExpiresAt)),
-                new(builder.Ascending(x => x.Retries)),
-                new(builder.Ascending(x => x.Version)),
-                new(builder.Ascending(x => x.StatusName).Ascending(x => x.ExpiresAt))
+                new(builder.Ascending(x => x.StatusName).Ascending(x => x.ExpiresAt)),
+                new(builder.Ascending(x => x.StatusName).Ascending(x => x.Added))
             };
 
             await col.Indexes.CreateManyAsync(indexes, cancellationToken);
@@ -131,7 +125,9 @@ public class MongoDBStorageInitializer : IStorageInitializer
 
         async Task DropReceivedMessageDeprecatedIndexesAsync()
         {
-            var obsoleteIndexes = new HashSet<string> { "Name", "Added", "ExpiresAt", "StatusName", "Retries", "Version" };
+            var obsoleteIndexes = new HashSet<string> { 
+                "Name", "Added", "ExpiresAt", "StatusName", "Retries", "Version",
+                "Added_1", "ExpiresAt_1", "StatusName_1", "Retries_1", "Version_1" };
            
             var col = database.GetCollection<ReceivedMessage>(options.ReceivedCollection);
            
@@ -140,7 +136,11 @@ public class MongoDBStorageInitializer : IStorageInitializer
 
         async Task DropPublishedMessageDeprecatedIndexesAsync()
         {
-            var obsoleteIndexes = new HashSet<string> { "Name", "Added", "ExpiresAt", "StatusName", "Retries", "Version" };
+            var obsoleteIndexes = new HashSet<string>
+            {
+                "Name", "Added", "ExpiresAt", "StatusName", "Retries", "Version",
+                "Added_1", "ExpiresAt_1", "StatusName_1", "Retries_1", "Version_1"
+            };
             
             var col = database.GetCollection<PublishedMessage>(options.PublishedCollection);
            

--- a/src/DotNetCore.CAP.PostgreSql/IDataStorage.PostgreSql.cs
+++ b/src/DotNetCore.CAP.PostgreSql/IDataStorage.PostgreSql.cs
@@ -256,12 +256,11 @@ public class PostgreSqlDataStorage : IDataStorage
         CancellationToken token = default)
     {
         var sql =
-            $"SELECT \"Id\",\"Content\",\"Retries\",\"Added\",\"ExpiresAt\" FROM {_pubName} WHERE \"Version\"=@Version " +
-            $"AND ((\"ExpiresAt\"< @TwoMinutesLater AND \"StatusName\" = '{StatusName.Delayed}') OR (\"ExpiresAt\"< @OneMinutesAgo AND \"StatusName\" = '{StatusName.Queued}')) FOR UPDATE SKIP LOCKED LIMIT @BatchSize;";
+            $"SELECT \"Id\",\"Content\",\"Retries\",\"Added\",\"ExpiresAt\" FROM {_pubName} WHERE " +
+            $"((\"ExpiresAt\"< @TwoMinutesLater AND \"StatusName\" = '{StatusName.Delayed}') OR (\"ExpiresAt\"< @OneMinutesAgo AND \"StatusName\" = '{StatusName.Queued}')) ORDER BY \"Added\" FOR UPDATE SKIP LOCKED LIMIT @BatchSize;";
 
         var sqlParams = new object[]
         {
-            new NpgsqlParameter("@Version", _capOptions.Value.Version),
             new NpgsqlParameter("@TwoMinutesLater", DateTime.Now.AddMinutes(2)),
             new NpgsqlParameter("@OneMinutesAgo", QueuedMessageFetchTime()),
             new NpgsqlParameter("@BatchSize", _capOptions.Value.SchedulerBatchSize)
@@ -347,12 +346,11 @@ public class PostgreSqlDataStorage : IDataStorage
         var fourMinAgo = DateTime.Now.Subtract(lookbackSeconds);
         var sql =
             $"SELECT \"Id\",\"Content\",\"Retries\",\"Added\" FROM {tableName} WHERE \"Retries\"<@Retries " +
-            $"AND \"Version\"=@Version AND \"Added\"<@Added AND \"StatusName\" IN ('{StatusName.Failed}','{StatusName.Scheduled}') LIMIT 200;";
+            $"AND \"Added\"<@Added AND \"StatusName\" IN ('{StatusName.Failed}','{StatusName.Scheduled}') ORDER BY \"Added\" LIMIT 200;";
 
         object[] sqlParams =
         {
             new NpgsqlParameter("@Retries", _capOptions.Value.FailedRetryCount),
-            new NpgsqlParameter("@Version", _capOptions.Value.Version),
             new NpgsqlParameter("@Added", fourMinAgo)
         };
 

--- a/src/DotNetCore.CAP.PostgreSql/IMonitoringApi.PostgreSql.cs
+++ b/src/DotNetCore.CAP.PostgreSql/IMonitoringApi.PostgreSql.cs
@@ -87,7 +87,7 @@ SELECT
         var tableName = queryDto.MessageType == MessageType.Publish ? _pubName : _recName;
         var where = string.Empty;
 
-        if (!string.IsNullOrEmpty(queryDto.StatusName)) where += " AND Lower(\"StatusName\") = Lower(@StatusName)";
+        if (!string.IsNullOrEmpty(queryDto.StatusName)) where += " AND \"StatusName\" = @StatusName";
 
         if (!string.IsNullOrEmpty(queryDto.Name)) where += " AND Lower(\"Name\") = Lower(@Name)";
 

--- a/src/DotNetCore.CAP.PostgreSql/IStorageInitializer.PostgreSql.cs
+++ b/src/DotNetCore.CAP.PostgreSql/IStorageInitializer.PostgreSql.cs
@@ -76,8 +76,11 @@ CREATE TABLE IF NOT EXISTS {GetReceivedTableName()}(
 	""StatusName"" VARCHAR(50) NOT NULL
 );
 
-CREATE INDEX IF NOT EXISTS ""idx_received_ExpiresAt_StatusName"" ON {GetReceivedTableName()} (""ExpiresAt"",""StatusName"");
-CREATE INDEX IF NOT EXISTS ""idx_received_Version_ExpiresAt_StatusName"" ON {GetReceivedTableName()} (""Version"",""ExpiresAt"",""StatusName"");
+
+CREATE INDEX IF NOT EXISTS ""idx_received_StatusName_ExpiresAt"" ON {GetReceivedTableName()} (""StatusName"",""ExpiresAt"");
+CREATE INDEX IF NOT EXISTS ""idx_received_StatusName_Added"" ON {GetReceivedTableName()} (""StatusName"",""Added"");
+DROP INDEX IF EXISTS ""idx_received_ExpiresAt_StatusName"";
+DROP INDEX IF EXISTS ""idx_received_Version_ExpiresAt_StatusName"";
 
 CREATE TABLE IF NOT EXISTS {GetPublishedTableName()}(
 	""Id"" BIGINT PRIMARY KEY NOT NULL,
@@ -90,8 +93,11 @@ CREATE TABLE IF NOT EXISTS {GetPublishedTableName()}(
 	""StatusName"" VARCHAR(50) NOT NULL
 );
 
-CREATE INDEX IF NOT EXISTS ""idx_published_ExpiresAt_StatusName"" ON {GetPublishedTableName()}(""ExpiresAt"",""StatusName"");
-CREATE INDEX IF NOT EXISTS ""idx_published_Version_ExpiresAt_StatusName"" ON {GetPublishedTableName()} (""Version"",""ExpiresAt"",""StatusName"");";
+
+CREATE INDEX IF NOT EXISTS ""idx_published_StatusName_ExpiresAt"" ON {GetPublishedTableName()} (""StatusName"",""ExpiresAt"");
+CREATE INDEX IF NOT EXISTS ""idx_published_StatusName_Added"" ON {GetPublishedTableName()} (""StatusName"",""Added"");
+DROP INDEX IF EXISTS ""idx_published_ExpiresAt_StatusName"";
+DROP INDEX IF EXISTS ""idx_published_Version_ExpiresAt_StatusName"";";
 
         if (_capOptions.Value.UseStorageLock)
             batchSql += $@"


### PR DESCRIPTION
The `Version` field was scoping retry and scheduler queries to messages
produced by the currently-running app version. In practice this prevented
older messages from ever being retried after a deployment, causing silent
message loss. This PR removes that constraint so all eligible messages are
processed regardless of version.

**What changed:**

- **Version filter removed** — `GetPublishedMessagesOfNeedRetry`,
  `GetReceivedMessagesOfNeedRetry`, and `ScheduleMessagesOfDelayedAsync`
  no longer filter by `Version` in both MongoDB and PostgreSQL storage.
- **FIFO ordering** — retry and scheduler queries now order by `Added`
  so older messages are always processed first.
- **Indexes optimised** — replaced individual-field indexes with compound
  `(StatusName, ExpiresAt)` and `(StatusName, Added)` indexes (MongoDB +
  PostgreSQL); old indexes are dropped automatically on startup.
- **Dashboard status fix** — `NormalizeStatus` does case-insensitive
  matching so dashboard URLs like `/failed` and `/Failed` both work.
- **Content search hardened** — MongoDB content search now uses
  `Regex.Escape` to prevent user input from being interpreted as a regex
  pattern.
- **PostgreSQL status query** — uses exact equality on `StatusName`
  instead of `Lower()`, allowing the new compound index to be used.

https://cteleport.atlassian.net/browse/AR-292